### PR TITLE
WIP: Upgrade Tomcat to 11.0.18 (Jakarta EE 11)

### DIFF
--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -13,12 +13,12 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@v4.1.7
         with:
-          ref: develop
+          ref: jakarta
 
       - uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
-          java-version: '8'
+          distribution: 'temurin'
+          java-version: '21'
           java-package: jdk
           architecture: x64
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.dbflute.tomcat</groupId>
 	<artifactId>tomcat-boot</artifactId>
-	<version>2.0.1</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Tomcat Boot</name>
@@ -13,8 +13,8 @@
 	<inceptionYear>2015</inceptionYear>
 
 	<properties>
-		<servlet.version>6.0.0</servlet.version>
-		<tomcat.version>10.1.52</tomcat.version>
+		<servlet.version>6.1.0</servlet.version>
+		<tomcat.version>11.0.18</tomcat.version>
 		<utflute.version>2.0.0</utflute.version>
 	</properties>
 
@@ -241,12 +241,12 @@
 
 		<dependency> <!-- needed in various case for e.g. hibernate validator -->
 			<groupId>org.apache.tomcat</groupId>
-			<artifactId>tomcat-el-api</artifactId> <!-- javax.el interface -->
+			<artifactId>tomcat-el-api</artifactId> <!-- jakarta.el interface -->
 			<version>${tomcat.version}</version>
 		</dependency>
 		<dependency> <!-- me too -->
 			<groupId>org.apache.tomcat</groupId>
-			<artifactId>tomcat-jasper-el</artifactId> <!-- javax.el implementation -->
+			<artifactId>tomcat-jasper-el</artifactId> <!-- jakarta.el implementation -->
 			<version>${tomcat.version}</version>
 		</dependency>
 

--- a/src/main/java/org/apache/catalina/startup/RhythmicalContextConfig.java
+++ b/src/main/java/org/apache/catalina/startup/RhythmicalContextConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/tomcat/TomcatBoot.java
+++ b/src/main/java/org/dbflute/tomcat/TomcatBoot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/tomcat/core/RhythmicalHandlingDef.java
+++ b/src/main/java/org/dbflute/tomcat/core/RhythmicalHandlingDef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/tomcat/core/RhythmicalTomcat.java
+++ b/src/main/java/org/dbflute/tomcat/core/RhythmicalTomcat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -117,7 +117,7 @@ public class RhythmicalTomcat extends Tomcat { // e.g. to remove org.eclipse.jet
         final Context ctx = createContext(host, contextPath);
         ctx.setPath(contextPath);
         ctx.setDocBase(docBase);
-        ctx.addLifecycleListener(newDefaultWebXmlListener()); // *extension point
+        ctx.addLifecycleListener(getDefaultWebXmlListener()); // *extension point
         ctx.setConfigFile(getWebappConfigFile(docBase, contextPath));
 
         ctx.addLifecycleListener(config);
@@ -191,7 +191,8 @@ public class RhythmicalTomcat extends Tomcat { // e.g. to remove org.eclipse.jet
     // -----------------------------------------------------
     //                                       WebXml Listener
     //                                       ---------------
-    protected DefaultWebXmlListener newDefaultWebXmlListener() {
+    @Override
+    public LifecycleListener getDefaultWebXmlListener() {
         return new DefaultWebXmlListener() {
             @Override
             public void lifecycleEvent(LifecycleEvent event) {

--- a/src/main/java/org/dbflute/tomcat/core/accesslog/AccessLogOption.java
+++ b/src/main/java/org/dbflute/tomcat/core/accesslog/AccessLogOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/tomcat/core/likeit/LikeItCatalinaResource.java
+++ b/src/main/java/org/dbflute/tomcat/core/likeit/LikeItCatalinaResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/tomcat/core/likeit/LikeItCatalinaSetupper.java
+++ b/src/main/java/org/dbflute/tomcat/core/likeit/LikeItCatalinaSetupper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/tomcat/core/valve/YourValveOption.java
+++ b/src/main/java/org/dbflute/tomcat/core/valve/YourValveOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/tomcat/logging/BootLogger.java
+++ b/src/main/java/org/dbflute/tomcat/logging/BootLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/tomcat/logging/LinerLogFormatter.java
+++ b/src/main/java/org/dbflute/tomcat/logging/LinerLogFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/tomcat/logging/ServerLoggingLoader.java
+++ b/src/main/java/org/dbflute/tomcat/logging/ServerLoggingLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/tomcat/logging/TomcatLoggingOption.java
+++ b/src/main/java/org/dbflute/tomcat/logging/TomcatLoggingOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/tomcat/props/BootPropsTranslator.java
+++ b/src/main/java/org/dbflute/tomcat/props/BootPropsTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/tomcat/util/BotmReflectionUtil.java
+++ b/src/main/java/org/dbflute/tomcat/util/BotmReflectionUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/dbflute/tomcat/util/BotmResourceUtil.java
+++ b/src/main/java/org/dbflute/tomcat/util/BotmResourceUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
Migrate from Tomcat 10.1.52 to Tomcat 11.0.18, adopting Jakarta EE 11 (Servlet 6.1, EL 6.0). This is a major version bump (2.0.1 → 3.0.0-SNAPSHOT) reflecting the Tomcat major version change.

## Changes Made
- **pom.xml**: Bump `tomcat.version` to 11.0.18, `servlet.version` to 6.1.0, project version to 3.0.0-SNAPSHOT. Fix EL dependency comments (`javax.el` → `jakarta.el`)
- **RhythmicalTomcat.java**: Replace `newDefaultWebXmlListener()` with `@Override getDefaultWebXmlListener()` to align with Tomcat 11's new public API for controlling DefaultWebXmlListener
- **GitHub Actions**: Update workflow to use Java 21, Temurin distribution, and `jakarta` branch
- **Copyright**: Update all source file headers from 2015-2024 to 2015-2026

## Testing
- `./mvnw compile` — passes, confirming API compatibility for RhythmicalContextConfig, BootPropsTranslator, and TomcatBoot
- `./mvnw test` — BUILD SUCCESS
- Tasks 3-5 (RhythmicalContextConfig, BootPropsTranslator, TomcatBoot) confirmed no changes needed via compilation

## Breaking Changes
- Minimum Tomcat version is now 11.0.x (requires Java 17+, project uses Java 21)
- Servlet API upgraded from 6.0.0 to 6.1.0

## Additional Notes
- All Tomcat APIs used by this library were verified via javap against Tomcat 11.0.7 JARs prior to implementation
- `newDefaultWebXmlListener()` is replaced by overriding `getDefaultWebXmlListener()` which Tomcat 11 introduced as a public method on the `Tomcat` class